### PR TITLE
Deposit Refund Wallet Smart Contract (Clarity).

### DIFF
--- a/shiny_contract/Clarinet.toml
+++ b/shiny_contract/Clarinet.toml
@@ -5,6 +5,11 @@ authors = []
 telemetry = true
 cache_dir = '.\.cache'
 requirements = []
+[contracts.deposit_refund_wallet]
+path = 'contracts/deposit_refund_wallet.clar'
+clarity_version = 2
+epoch = 2.5
+
 [contracts.storage_expiration]
 path = 'contracts/storage_expiration.clar'
 clarity_version = 2

--- a/shiny_contract/contracts/deposit_refund_wallet.clar
+++ b/shiny_contract/contracts/deposit_refund_wallet.clar
@@ -1,0 +1,154 @@
+;; Deposit Refund Wallet Smart Contract
+;; Automatically refunds excess deposits when they exceed the maximum balance
+
+;; Error constants
+(define-constant ERR-UNAUTHORIZED (err u1001))
+(define-constant ERR-INVALID-AMOUNT (err u1002))
+(define-constant ERR-INSUFFICIENT-BALANCE (err u1003))
+(define-constant ERR-TRANSFER-FAILED (err u1004))
+
+;; Contract owner
+(define-constant CONTRACT-OWNER tx-sender)
+
+;; Data variables
+(define-data-var max-balance uint u1000000) ;; Default max balance (1,000,000 microSTX)
+(define-data-var current-balance uint u0)
+
+;; Read-only functions
+
+;; Get the maximum allowed balance
+(define-read-only (get-max-balance)
+  (var-get max-balance)
+)
+
+;; Get the current wallet balance
+(define-read-only (get-current-balance)
+  (var-get current-balance)
+)
+
+;; Get available deposit space (how much can be deposited without exceeding max)
+(define-read-only (get-available-space)
+  (let ((max (var-get max-balance))
+        (current (var-get current-balance)))
+    (if (>= current max)
+        u0
+        (- max current)
+    )
+  )
+)
+
+;; Check if an amount would exceed the maximum balance
+(define-read-only (would-exceed-max (amount uint))
+  (let ((current (var-get current-balance))
+        (max (var-get max-balance)))
+    (> (+ current amount) max)
+  )
+)
+
+;; Calculate refund amount for a given deposit
+(define-read-only (calculate-refund (deposit-amount uint))
+  (let ((current (var-get current-balance))
+        (max (var-get max-balance))
+        (new-total (+ current deposit-amount)))
+    (if (> new-total max)
+        (- new-total max)
+        u0
+    )
+  )
+)
+
+;; Public functions
+
+;; Set the maximum balance (only contract owner)
+(define-public (set-max-balance (new-max uint))
+  (begin
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (asserts! (> new-max u0) ERR-INVALID-AMOUNT)
+    (var-set max-balance new-max)
+    (ok new-max)
+  )
+)
+
+;; Deposit STX with automatic refund of excess
+(define-public (deposit (amount uint))
+  (let ((current (var-get current-balance))
+        (max (var-get max-balance))
+        (new-total (+ current amount))
+        (accepted-amount (if (> new-total max) (- max current) amount))
+        (refund-amount (if (> new-total max) (- new-total max) u0)))
+    
+    ;; Validate deposit amount
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    
+    ;; Transfer the full deposit amount from sender to contract
+    (try! (stx-transfer? amount tx-sender (as-contract tx-sender)))
+    
+    ;; Update the balance with only the accepted amount
+    (var-set current-balance (+ current accepted-amount))
+    
+    ;; If there's a refund, send it back to the depositor
+    (if (> refund-amount u0)
+        (begin
+          (try! (as-contract (stx-transfer? refund-amount tx-sender tx-sender)))
+          (ok {
+            deposited: accepted-amount,
+            refunded: refund-amount,
+            new-balance: (+ current accepted-amount)
+          })
+        )
+        (ok {
+          deposited: accepted-amount,
+          refunded: u0,
+          new-balance: (+ current accepted-amount)
+        })
+    )
+  )
+)
+
+;; Withdraw STX (only contract owner)
+(define-public (withdraw (amount uint))
+  (let ((current (var-get current-balance)))
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    (asserts! (> amount u0) ERR-INVALID-AMOUNT)
+    (asserts! (<= amount current) ERR-INSUFFICIENT-BALANCE)
+    
+    ;; Transfer STX from contract to owner
+    (try! (as-contract (stx-transfer? amount tx-sender CONTRACT-OWNER)))
+    
+    ;; Update balance
+    (var-set current-balance (- current amount))
+    
+    (ok {
+      withdrawn: amount,
+      new-balance: (- current amount)
+    })
+  )
+)
+
+;; Emergency withdraw all funds (only contract owner)
+(define-public (emergency-withdraw)
+  (let ((current (var-get current-balance)))
+    (asserts! (is-eq tx-sender CONTRACT-OWNER) ERR-UNAUTHORIZED)
+    
+    ;; Transfer all STX from contract to owner
+    (try! (as-contract (stx-transfer? current tx-sender CONTRACT-OWNER)))
+    
+    ;; Reset balance
+    (var-set current-balance u0)
+    
+    (ok {
+      withdrawn: current,
+      new-balance: u0
+    })
+  )
+)
+
+;; Get contract info
+(define-read-only (get-contract-info)
+  {
+    owner: CONTRACT-OWNER,
+    max-balance: (var-get max-balance),
+    current-balance: (var-get current-balance),
+    available-space: (get-available-space)
+  }
+)

--- a/shiny_contract/tests/deposit_refund_wallet.test.ts
+++ b/shiny_contract/tests/deposit_refund_wallet.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Deposit Refund Wallet Smart Contract

## Overview

The **Deposit Refund Wallet** is a small, secure Clarity contract that accepts STX deposits up to a configurable `max-balance`. Any deposit that would push the contract above that maximum is **partially accepted** and the excess is immediately **refunded** to the depositor.

This pattern is useful when you want to accept payments up to a cap (e.g., per-period collection, treasury bucket, or funding target) and ensure senders are not left with stuck funds when the cap is reached.

---

## Key Concepts

* `max-balance`: the maximum STX amount the wallet should hold (in microSTX). Default: `1_000_000` (1 STX in micro-units for example).
* `current-balance`: tracked contract balance (kept on-chain separately from the contract's actual STX balance for accounting).
* Deposits larger than the available space are accepted up to the available space; the remainder is returned to the depositor.
* Only the contract owner (`CONTRACT-OWNER`) can change the `max-balance` and perform withdrawals.

---

## Public API

### Read-only

* `get-max-balance()` → returns `max-balance`.
* `get-current-balance()` → returns `current-balance` (accounting variable).
* `get-available-space()` → returns how much more can be deposited without exceeding `max-balance`.
* `would-exceed-max(amount)` → boolean whether a deposit of `amount` would exceed the maximum.
* `calculate-refund(deposit-amount)` → returns how much would be refunded if `deposit-amount` is sent.
* `get-contract-info()` → returns a summary object with `owner`, `max-balance`, `current-balance`, and `available-space`.

### State-changing

* `set-max-balance(new-max)` — owner-only. Update the `max-balance` to a new limit. Reverts if `new-max` is zero.

* `deposit(amount)` — deposit `amount` STX into the contract. Behavior:

  1. Transfer `amount` STX from caller to the contract.
  2. Compute `accepted-amount = min(amount, available-space)` and `refund-amount = amount - accepted-amount`.
  3. Update `current-balance` by `accepted-amount`.
  4. If `refund-amount > 0`, transfer it back to the depositor.
  5. Return a structured object: `{ deposited, refunded, new-balance }`.

* `withdraw(amount)` — owner-only. Transfer `amount` STX from contract to owner and update `current-balance` accordingly.

* `emergency-withdraw()` — owner-only. Transfer **all** `current-balance` to owner and reset `current-balance` to zero.

---

## Errors / Reverts

* `ERR-UNAUTHORIZED (u1001)` — caller lacks owner privileges for owner-only functions.
* `ERR-INVALID-AMOUNT (u1002)` — deposit/withdraw amount must be greater than zero.
* `ERR-INSUFFICIENT-BALANCE (u1003)` — attempted withdrawal exceeds `current-balance`.
* `ERR-TRANSFER-FAILED (u1004)` — STX transfer primitive failed (rare; forwarded by `try!`).

---

## Important Implementation Notes

* **Accounting vs native balance:** The contract maintains a `current-balance` variable as its canonical accounting source. The contract also performs actual `stx-transfer?` calls to move funds. Keep `current-balance` consistent with on-chain STX balance in external monitoring — if transfers fail or someone sends STX directly to the contract outside `deposit`, balances may diverge.

* **Atomic refund behavior:** `deposit` first transfers the full `amount` into the contract, then attempts to refund any excess. If the refund transfer fails, the whole call will revert due to `try!` behavior — preventing accidental acceptance of excess funds.

* **Reentrancy & safety:** Clarity is intentionally free of EVM-style reentrancy; state changes are expressed declaratively. Still, rely on `try!`/`as-contract` patterns carefully.

* **Denominations:** All amounts are in the smallest STX unit (microSTX). Convert human-readable amounts in off-chain code accordingly.

---

## Typical Workflows

### 1) Depositor (normal case)

1. Caller checks `get-available-space()`.
2. Caller calls `deposit(amount)`.
3. If `amount <= available-space`:

   * `accepted-amount = amount`, `refunded = 0`.
   * `current-balance` increases by `amount`.

### 2) Depositor (over-cap case)

1. Caller calls `deposit(amount)` where `amount > available-space`.
2. Contract accepts `accepted-amount = available-space` and refunds `refund-amount = amount - available-space`.
3. Response includes deposited and refunded amounts so caller can confirm.

### 3) Owner withdrawals

* Owner calls `withdraw(amount)` for routine draining (must be ≤ `current-balance`).
* In emergencies, owner calls `emergency-withdraw()` to clear the contract.

---

## Security & Operational Considerations

1. **Owner Privileges:** The owner can change `max-balance` and withdraw funds. Use a multisig for production ownership where appropriate.
2. **Direct STX transfers:** If STX are transferred directly to the contract account (not using `deposit`), `current-balance` won't automatically reflect those transfers. Consider adding a reconciliation function or require deposits to go through `deposit()` only.
3. **Refund Failures:** Refund transfers are performed with `as-contract` and wrapped in `try!`. If refunds cannot be sent, transactions revert — this preserves correctness but may impact UX if gas conditions are unusual.
4. **Integer arithmetic:** All math is integer; ensure off-chain clients handle rounding and units consistently.

---

## Testing Recommendations

* Unit tests for `calculate-refund` across edge cases (exact cap, small overflows, zero deposits).
* Tests where multiple depositors fill the cap sequentially.
* Tests for owner-only functions (`withdraw`, `set-max-balance`, `emergency-withdraw`) and failure paths.
* Tests for failing refund scenarios (simulate transfer failures) to ensure `deposit` reverts and leaves state consistent.

---

## Example Usage (pseudo)

```text
# Owner sets max balance to 5 STX (in microSTX)
call set-max-balance(u5000000)

# User attempts to deposit 3 STX
call deposit(u3000000)
# -> { deposited: 3000000, refunded: 0, new-balance: 3000000 }

# Another user attempts to deposit 4 STX (would exceed cap by 2 STX)
call deposit(u4000000)
# -> { deposited: 2000000, refunded: 2000000, new-balance: 5000000 }

# Owner withdraws 1 STX
call withdraw(u1000000)
# -> { withdrawn: 1000000, new-balance: 4000000 }

# Emergency withdraw all remaining funds
call emergency-withdraw()
# -> { withdrawn: 4000000, new-balance: 0 }
```

---

## Improvements & TODOs

* Add an on-chain reconciliation function to sync `current-balance` with the contract's actual STX balance when needed.
* Add event/logging (`print`) for deposits, refunds and withdrawals to support off-chain indexers.
* Consider access control for `set-max-balance` via a multisig or a governance module in production.

---

## License

MIT

---